### PR TITLE
Find mbti accounts - 0428

### DIFF
--- a/.idea/Instagram_crawling.iml
+++ b/.idea/Instagram_crawling.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.9 (캡스톤디자인)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (캡스톤디자인)" project-jdk-type="Python SDK" />
 </project>

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import requests
 from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.keys import Keys
 import openpyxl
 import time
 import re
@@ -27,6 +28,7 @@ def get_crawl(URL):
     return crawl_data
 
 # login 유지
+
 driver.implicitly_wait(3)
 driver.get("https://www.instagram.com/accounts/login/")
 login_x_path = '/html/body/div[1]/section/main/div/div/div[1]/div/form/div/div[3]/button'
@@ -56,29 +58,40 @@ search_bio = driver.find_elements_by_css_selector("div._7UhW9.xLCgt.MMzan._0PwGv
 
 max = 15
 cnt = 0
+
+
+
 # 들어가야하는 계정 선택
 for i in range(len(search_id)):
     print(search_name, search_id[i].text)
     if search_name not in search_id[i].text:
         secret = 0
-        cnt+=1
+
         print(search_id[i].text)
-        search_id[i].click()
-        element = driver.find_element_by_css_selector('div.QlxVY')
-        print(element)
-        if element is not None:
+        #time.sleep(3)
+        #search_id[i].click()
+        driver.execute_script("arguments[0].click();", search_id[i])
+        elements = driver.find_element_by_css_selector('article.ySN3v').text
+
+        if elements:
+            # 비공개 계정
             secret = 1
             print(secret)
-        else :
+        else:
+            # 공개 계정
+            cnt += 1
+            # 필요한 정보 크롤링
             print(secret)
+
 
         driver.back()
         driver.find_element_by_xpath(search_xpath).send_keys(search_name)
         search_id = driver.find_elements_by_css_selector("div._7UhW9.xLCgt.qyrsm.KV-D4.uL8Hv")
+        if max == cnt:
+            print(f"mbti {search_name}의 계정을 총 {max}개 찾았습니다")
 
 
-
-# search_bio =
+print(f"mbti {search_name}의 계정을 총 {cnt}개 찾았습니다")
 
 # 컨테이너(포스트) 12개 저장
 instagram = driver.find_elements_by_css_selector("div.v1Nh3")


### PR DESCRIPTION
find version of only 'ISTJ'

1) 해당 mbti (istj) 를 검색한다
2) 뜨는 사람들 중에, 공계(홍보계정)을 피하기 위해  ID에 직접적으로 mbti가 등장하는 사람은 제외, 자신의 bio에만 mbti를 설명한 사람들만 채택한다
3) 그 중에서도 비공개인 사람들은 크롤링할 수 있는 정보가 제한적이므로, 비공개인지 아닌지 판단 flag을 출력한다

** 필요한 추가구현 사항 **
-다른 mbti에 대해서도 확인
-mbti계정의 개수가 원하는 만큼 찾아지지 않았을 때의 대안
- 해당 계정에 접속하여서 원하는 데이터(팔로잉,팔로워수...등등) 크롤링 